### PR TITLE
[UPD] Resolves #11. Change URLs so Formio JS client doesn't strip the…

### DIFF
--- a/formio/__manifest__.py
+++ b/formio/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Form.io',
     'summary': 'Build, publish and store webforms in Odoo with the "Form.io" GUI/renderer',
-    'version': '1.7',
+    'version': '1.8',
     'author': 'Nova Code',
     'website': 'https://www.novacode.nl',
     'license': 'LGPL-3',

--- a/formio/models/formio_builder.py
+++ b/formio/models/formio_builder.py
@@ -179,14 +179,6 @@ class Builder(models.Model):
             r.act_window_url = url
 
     @api.multi
-    def action_formio_builder(self):
-        return {
-            'type': 'ir.actions.act_url',
-            'url': self.edit_url,
-            'target': 'self',
-        }
-
-    @api.multi
     def action_client_formio_builder(self):
         return {
             'type': 'ir.actions.client',

--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -231,14 +231,6 @@ class Form(models.Model):
             r.res_info = False
         
     @api.multi
-    def action_formio(self):
-        return {
-            'type': 'ir.actions.act_url',
-            'url': self.url,
-            'target': 'self',
-        }
-
-    @api.multi
     def action_open_res_act_window(self):
         raise NotImplementedError
 

--- a/formio/static/description/index.html
+++ b/formio/static/description/index.html
@@ -116,6 +116,17 @@
 <section class="oe_container oe_dark">
   <div class="oe_row oe_spaced">
     <h2 class="oe_slogan" style="color:#875A7B;">Changelog</h2>
+    <h4 class="oe_mb16">1.8</h4>
+    <ul>
+      <li>
+        Change URLs and controllers FROM <code>/formio/form/&lt;action&gt;/&lt;string:uuid&gt;</code> URLs TO <code>/formio/form/&lt;string:uuid&gt;/&lt;action&gt;</code>. This solves issues regarding relative URLs from a Formio Javascript perspective (components).
+        The UUID was stripped by the Formio Javascript client API.<br/>
+        Should solve: <a href="https://github.com/novacode-nl/odoo-formio/issues/11" target="_blank">https://github.com/novacode-nl/odoo-formio/issues/11</a>
+      </li>
+      <li>
+        Remove 2 legacy (obsolete) controller methods for routes: <code>/formio/form/&lt;string:uuid&gt;</code> and <code>/formio/builder/&lt;int:builder_id&gt;</code>
+      </li>
+    </ul>
     <h4 class="oe_mb16">1.7</h4>
     <ul>
       <li>

--- a/formio/static/src/js/formio_form.js
+++ b/formio/static/src/js/formio_form.js
@@ -4,10 +4,11 @@
 $(document).ready(function() {
     var uuid = document.getElementById('form_uuid').value,
         base_url = window.location.protocol + '//' + window.location.host,
-        schema_url = '/formio/form/schema/' + uuid,
-        options_url = '/formio/form/options/' + uuid,
-        submission_url = '/formio/form/submission/' + uuid,
-        submit_url = '/formio/form/submit/' + uuid,
+        formio_uuid = '/formio/form/' + uuid,
+        schema_url = formio_uuid + '/schema/',
+        options_url = formio_uuid + '/options/',
+        submission_url = formio_uuid + '/submission/',
+        submit_url = formio_uuid + '/submit/',
         schema = {},
         options = {};
 

--- a/formio/static/src/xml/formio.xml
+++ b/formio/static/src/xml/formio.xml
@@ -55,7 +55,7 @@
                     <button id="fullscreen_formio" class="pull-right">Fullscreen (Exit with ESC)</button>
                 </div>
                 </div>
-                <iframe t-attf-src="/formio/builder/embed/#{widget.builder.id}" id="formio_builder_embed" allowfullscreen="true"></iframe>
+                <iframe t-attf-src="/formio/builder/#{widget.builder.id}" id="formio_builder_embed" allowfullscreen="true"></iframe>
                 <script>
                     var fullscreen = document.getElementById('fullscreen_formio');
                     var iframe = document.getElementById('formio_builder_embed');
@@ -110,7 +110,7 @@
                         <t t-esc="widget.form.title"/>
                     </h1>
                 </div>
-                <iframe t-attf-src="/formio/form/embed/#{widget.form.uuid}" id="formio_form_embed"/>
+                <iframe t-attf-src="/formio/form/#{widget.form.uuid}/root" id="formio_form_embed"/>
                 <script>
                     iFrameResize({}, '#formio_form_embed')
                 </script>

--- a/formio/views/formio_form_views.xml
+++ b/formio/views/formio_form_views.xml
@@ -49,7 +49,7 @@ See LICENSE file for full licensing details. -->
                                         <strong class="o_kanban_record_title"><field name="title"/></strong><br/>
                                         <div>
                                             <div class="mt8">
-                                                <button class="btn btn-primary" name="action_formio" type="object" role="button">Form</button>
+                                                <button name="action_client_formio_form" type="object" role="button" class="btn btn-primary">Form</button>
                                             </div>
                                         </div>
                                     </div>

--- a/formio/views/formio_portal_templates.xml
+++ b/formio/views/formio_portal_templates.xml
@@ -152,7 +152,7 @@ See LICENSE file for full licensing details. -->
                             <t t-esc="form.title"/>
                         </h1>
                     </div>
-                    <iframe t-attf-src="/formio/form/embed/#{form.uuid}" id="formio_form_embed"/>
+                    <iframe t-attf-src="/formio/form/#{form.uuid}/root" id="formio_form_embed"/>
                     <script type="text/javascript">
                         // TODO move to Javascript file.
                         iFrameResize({}, '#formio_form_embed')


### PR DESCRIPTION
… UUID.

- Change URLs and controllers FROM /formio/form/<action>/<string:uuid> URLs TO /formio/form/<string:uuid>/<action>.
This hopefully solves issues regarding relative URLs from a Formio Javascript perspective (components).
The UUID was stripped by the Formio Javascript client API.

- Remove 2 legacy (obsolete) controller methods for routes: /formio/form/<string:uuid> and /formio/builder/<int:builder_id>.