### PR TITLE
[FIX] formio.js GitHub releases: obtaining the latest 30 release versions often get 403 errors

### DIFF
--- a/formio/i18n/zh_CN.po
+++ b/formio/i18n/zh_CN.po
@@ -427,8 +427,8 @@ msgstr "可用"
 
 #. module: formio
 #: model:ir.model.fields,field_description:formio.field_formio_version_github_checker_wizard__available_version_github_tag_ids
-msgid "Available Version Github Tag"
-msgstr "可用版本Github标签"
+msgid "Available Version GitHub Tag"
+msgstr "可用版本GitHub标签"
 
 #. module: formio
 #: model_terms:ir.ui.view,arch_db:formio.view_formio_version_github_checker_wizard

--- a/formio/models/res_config_settings.py
+++ b/formio/models/res_config_settings.py
@@ -11,7 +11,7 @@ class ResConfigSettings(models.TransientModel):
     formio_default_asset_css_ids = fields.Many2many('formio.default.asset.css', string='Form.io CSS assets')
     formio_default_builder_js_options_id = fields.Many2one('formio.builder.js.options', string='Form.io Builder JS options ID')
     formio_default_builder_js_options = fields.Text(related='formio_default_builder_js_options_id.value', string='Form.io Builder JS options')
-    formio_github_personal_access_token = fields.Char(string='GitHub personal access token')
+    formio_default_github_personal_access_token = fields.Char(string='GitHub personal access token')
 
     @api.model
     def get_values(self):
@@ -40,10 +40,10 @@ class ResConfigSettings(models.TransientModel):
             res.update(
                 formio_default_asset_css_ids=default_asset_css
             )
-        default_formio_github_personal_access_token = Param.get_param('formio.github.personal.access.token')
-        if default_formio_github_personal_access_token:
+        default_github_personal_access_token = Param.get_param('formio.github.personal.access.token')
+        if default_github_personal_access_token:
             res.update(
-                formio_github_personal_access_token=default_formio_github_personal_access_token
+                formio_default_github_personal_access_token=default_github_personal_access_token
             )
         return res
 
@@ -59,7 +59,7 @@ class ResConfigSettings(models.TransientModel):
         )
         Param.sudo().set_param(
             "formio.github.personal.access.token",
-            self.formio_github_personal_access_token
+            self.formio_default_github_personal_access_token
         )
 
         context = {'active_test': False}

--- a/formio/models/res_config_settings.py
+++ b/formio/models/res_config_settings.py
@@ -11,6 +11,7 @@ class ResConfigSettings(models.TransientModel):
     formio_default_asset_css_ids = fields.Many2many('formio.default.asset.css', string='Form.io CSS assets')
     formio_default_builder_js_options_id = fields.Many2one('formio.builder.js.options', string='Form.io Builder JS options ID')
     formio_default_builder_js_options = fields.Text(related='formio_default_builder_js_options_id.value', string='Form.io Builder JS options')
+    github_personal_access_token = fields.Char(string='Github personal access token')
 
     @api.model
     def get_values(self):
@@ -37,7 +38,12 @@ class ResConfigSettings(models.TransientModel):
         default_asset_css = self.env['formio.default.asset.css'].with_context(context).search([])
         if default_asset_css:
             res.update(
-                formio_default_asset_css_ids=default_asset_css.ids
+                formio_default_asset_css_ids=default_asset_css
+            )
+        default_github_personal_access_token = Param.get_param('github.personal.access.token')
+        if default_github_personal_access_token:
+            res.update(
+                github_personal_access_token=default_github_personal_access_token
             )
         return res
 
@@ -50,6 +56,10 @@ class ResConfigSettings(models.TransientModel):
         Param.sudo().set_param(
             "formio.default_builder_js_options_id",
             self.formio_default_builder_js_options_id.id
+        )
+        Param.sudo().set_param(
+            "github.personal.access.token",
+            self.github_personal_access_token
         )
 
         context = {'active_test': False}

--- a/formio/models/res_config_settings.py
+++ b/formio/models/res_config_settings.py
@@ -11,7 +11,7 @@ class ResConfigSettings(models.TransientModel):
     formio_default_asset_css_ids = fields.Many2many('formio.default.asset.css', string='Form.io CSS assets')
     formio_default_builder_js_options_id = fields.Many2one('formio.builder.js.options', string='Form.io Builder JS options ID')
     formio_default_builder_js_options = fields.Text(related='formio_default_builder_js_options_id.value', string='Form.io Builder JS options')
-    formio_github_personal_access_token = fields.Char(string='Github personal access token')
+    formio_github_personal_access_token = fields.Char(string='GitHub personal access token')
 
     @api.model
     def get_values(self):

--- a/formio/models/res_config_settings.py
+++ b/formio/models/res_config_settings.py
@@ -11,7 +11,7 @@ class ResConfigSettings(models.TransientModel):
     formio_default_asset_css_ids = fields.Many2many('formio.default.asset.css', string='Form.io CSS assets')
     formio_default_builder_js_options_id = fields.Many2one('formio.builder.js.options', string='Form.io Builder JS options ID')
     formio_default_builder_js_options = fields.Text(related='formio_default_builder_js_options_id.value', string='Form.io Builder JS options')
-    github_personal_access_token = fields.Char(string='Github personal access token')
+    formio_github_personal_access_token = fields.Char(string='Github personal access token')
 
     @api.model
     def get_values(self):
@@ -40,10 +40,10 @@ class ResConfigSettings(models.TransientModel):
             res.update(
                 formio_default_asset_css_ids=default_asset_css
             )
-        default_github_personal_access_token = Param.get_param('github.personal.access.token')
-        if default_github_personal_access_token:
+        default_formio_github_personal_access_token = Param.get_param('formio.github.personal.access.token')
+        if default_formio_github_personal_access_token:
             res.update(
-                github_personal_access_token=default_github_personal_access_token
+                formio_github_personal_access_token=default_formio_github_personal_access_token
             )
         return res
 
@@ -58,8 +58,8 @@ class ResConfigSettings(models.TransientModel):
             self.formio_default_builder_js_options_id.id
         )
         Param.sudo().set_param(
-            "github.personal.access.token",
-            self.github_personal_access_token
+            "formio.github.personal.access.token",
+            self.formio_github_personal_access_token
         )
 
         context = {'active_test': False}

--- a/formio/views/res_config_settings_views.xml
+++ b/formio/views/res_config_settings_views.xml
@@ -32,7 +32,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                                     A scheduled action (daily cron) is available and already active.<br/>
                                     Source: <a href="https://github.com/formio/formio.js/releases" target="_blank">https://github.com/formio/formio.js/releases</a>
                                 </div>
-                                <strong>Github personal access token</strong><br/>
+                                <strong>GitHub personal access token</strong><br/>
                                 <field name="formio_github_personal_access_token"/><br/>
                                 <i class="fa fa-info-circle" title="info"/>
                                 <a href="https://github.com/settings/tokens" target="_blank">Token</a> is not required, but it can get a higher rate limit.

--- a/formio/views/res_config_settings_views.xml
+++ b/formio/views/res_config_settings_views.xml
@@ -33,7 +33,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                                     Source: <a href="https://github.com/formio/formio.js/releases" target="_blank">https://github.com/formio/formio.js/releases</a>
                                 </div>
                                 <strong>Github personal access token</strong><br/>
-                                <field name="github_personal_access_token"/><br/>
+                                <field name="formio_github_personal_access_token"/><br/>
                                 <i class="fa fa-info-circle" title="info"/>
                                 <a href="https://github.com/settings/tokens" target="_blank">Token</a> is not required, but it can get a higher rate limit.
                                 <div class="mt-4">

--- a/formio/views/res_config_settings_views.xml
+++ b/formio/views/res_config_settings_views.xml
@@ -33,7 +33,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                                     Source: <a href="https://github.com/formio/formio.js/releases" target="_blank">https://github.com/formio/formio.js/releases</a>
                                 </div>
                                 <strong>GitHub personal access token</strong><br/>
-                                <field name="formio_github_personal_access_token"/><br/>
+                                <field name="formio_default_github_personal_access_token"/><br/>
                                 <i class="fa fa-info-circle" title="info"/>
                                 <a href="https://github.com/settings/tokens" target="_blank">Token</a> is not required, but it can get a higher rate limit.
                                 <div class="mt-4">

--- a/formio/views/res_config_settings_views.xml
+++ b/formio/views/res_config_settings_views.xml
@@ -32,6 +32,10 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
                                     A scheduled action (daily cron) is available and already active.<br/>
                                     Source: <a href="https://github.com/formio/formio.js/releases" target="_blank">https://github.com/formio/formio.js/releases</a>
                                 </div>
+                                <strong>Github personal access token</strong><br/>
+                                <field name="github_personal_access_token"/><br/>
+                                <i class="fa fa-info-circle" title="info"/>
+                                <a href="https://github.com/settings/tokens" target="_blank">Token</a> is not required, but it can get a higher rate limit.
                                 <div class="mt-4">
                                     <button name="action_formio_version_github_importer" type="object"
                                             confirm="Are you sure to check for available versions? This could take some time to load, please be patient."

--- a/formio/wizard/formio_version_github_checker_wizard.py
+++ b/formio/wizard/formio_version_github_checker_wizard.py
@@ -2,6 +2,7 @@
 # See LICENSE file for full licensing details.
 
 import requests
+import urllib.request
 
 from odoo import api, fields, models, _
 
@@ -21,7 +22,11 @@ class VersionGitHubChecker(models.TransientModel):
     @api.model
     def check_new_versions(self):
         res = []
-        response = requests.get('https://api.github.com/repos/formio/formio.js/tags')
+        headers = {}
+        token = self.env['ir.config_parameter'].sudo().get_param('github.personal.access.token')
+        if token:
+            headers = {"Authorization": token}
+        response = requests.get('https://api.github.com/repos/formio/formio.js/tags', headers=headers)
 
         if response.status_code == 200:
             tags = response.json()

--- a/formio/wizard/formio_version_github_checker_wizard.py
+++ b/formio/wizard/formio_version_github_checker_wizard.py
@@ -2,8 +2,6 @@
 # See LICENSE file for full licensing details.
 
 import requests
-import urllib.request
-
 from odoo import api, fields, models, _
 
 

--- a/formio/wizard/formio_version_github_checker_wizard.py
+++ b/formio/wizard/formio_version_github_checker_wizard.py
@@ -21,7 +21,7 @@ class VersionGitHubChecker(models.TransientModel):
     def check_new_versions(self):
         res = []
         headers = {}
-        token = self.env['ir.config_parameter'].sudo().get_param('github.personal.access.token')
+        token = self.env['ir.config_parameter'].sudo().get_param('formio.github.personal.access.token')
         if token:
             headers = {"Authorization": token}
         response = requests.get('https://api.github.com/repos/formio/formio.js/tags', headers=headers)


### PR DESCRIPTION
formio.js GitHub releases: obtaining the latest 30 release versions often get 403 errors
