### PR TITLE
[13.0][FIX] Fix crm.lead action to form

### DIFF
--- a/formio_crm/__manifest__.py
+++ b/formio_crm/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Forms | CRM',
     'summary': 'Forms integration with CRM Leads',
-    'version': '0.2',
+    'version': '0.3',
     'license': 'LGPL-3',
     'author': 'Nova Code',
     'website': 'https://www.novacode.nl',
@@ -14,6 +14,7 @@
     'data': [
         'data/formio_crm_data.xml',
         'views/crm_lead_views.xml',
+        'views/formio_form_views.xml',
     ],
     'application': True,
     'images': [

--- a/formio_crm/views/crm_lead_views.xml
+++ b/formio_crm/views/crm_lead_views.xml
@@ -12,7 +12,7 @@ See LICENSE file for full licensing details. -->
                 <button
                     type="action"
                     name="%(formio.action_formio_form)d"
-                    context="{'search_default_res_id': id, 'search_default_res_model_id': formio_this_model_id, 'default_res_model_id': formio_this_model_id, 'default_res_id': id}"
+                    context="{'search_default_crm_lead_id': id, 'search_default_res_model_id': formio_this_model_id, 'default_res_model_id': formio_this_model_id, 'default_crm_lead_id': id}"
                     class="oe_stat_button"
                     icon="fa-file-text">
                     <field name="formio_forms_count" widget="statinfo" string="Forms"/>

--- a/formio_crm/views/formio_form_views.xml
+++ b/formio_crm/views/formio_form_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="view_formio_form_search" model="ir.ui.view">
+        <field name="name">formio.form.search.inherit</field>
+        <field name="model">formio.form</field>
+        <field name="inherit_id" ref="formio.view_formio_form_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='res_partner_id']" position="after">
+                <field name="crm_lead_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR fixes the incorrect action to open a form from a crm.lead. I fixed it by adding a search option for crm.lead on formio.form. Fix should be backported to v12/v11 if valid.

EDIT:
Issue also present in formio_sale