### PR TITLE
[FIX][11.0] Qweb textarea issue

### DIFF
--- a/formio_report_qweb/report/report_formio_form_components.xml
+++ b/formio_report_qweb/report/report_formio_form_components.xml
@@ -81,16 +81,14 @@ See LICENSE file for full copyright and licensing details.
     </template>
 
     <template id="textarea_component">
-        <t t-if="component['_object'].value">
-            <t t-set="value" t-value="component['_object'].value.replace('\n', '&lt;br/&gt;')"/>
-        </t>
-        <t t-else="">
-            <t t-set="value" t-value=""/>
-        </t>
         <div class="mw-100 mb-3 formio_textarea_component">
             <div class="label mb-2"><t t-call="formio_report_qweb.component_label"/></div>
             <!-- TODO FIX (security): split and loop lines, each with <t t-esc=...> -->
-            <p><t t-raw="value"/></p>
+            <p>
+                <t t-if="component['_object'].value">
+                    <t t-raw="component['_object'].value.replace('\n', '&lt;br/&gt;')"/>
+                </t>
+            </p>
         </div>
     </template>
 


### PR DESCRIPTION
This commit fixes this error:
```
Error when compiling AST
SyntaxError: unexpected EOF while parsing (<unknown>, line 0)
Template: formio_report_qweb.textarea_component
Path: /templates/t/t[1]
Node: <t t-if="component['_object'].value">
            <t t-set="value" t-value="component['_object'].value.replace('\n', '&lt;br/&gt;')"/>
        </t>
```