### PR TITLE
[FIX][11.] formio_data_api python dependency issue

### DIFF
--- a/formio_data_api/__manifest__.py
+++ b/formio_data_api/__manifest__.py
@@ -13,7 +13,7 @@
     'depends': ['formio'],
     'data': [],
     'external_dependencies': {
-        'python': ['formio-data'],
+        'python': ['formiodata'],
     },
     'application': False,
     'images': [


### PR DESCRIPTION
Error:
`Unable to upgrade module "formio_data_api" because an external dependency is not met: No module named formio-data`