### PR TITLE
Exclusive Forms for Portal users (respecting Partner hierarchy)

### DIFF
--- a/formio/__manifest__.py
+++ b/formio/__manifest__.py
@@ -42,6 +42,7 @@
         'views/formio_version_github_tag_views.xml',
         'views/formio_menu.xml',
         'views/res_config_settings_views.xml',
+        'views/res_partner_views.xml',
         'views/mail_activity_views.xml',
         # formio templates
         'views/formio_builder_templates.xml',

--- a/formio/__manifest__.py
+++ b/formio/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Forms',
     'summary': 'Form Builder & integration of professional and versatile Forms to collect any information you need for your business.',
-    'version': '8.17',
+    'version': '9.0',
     'license': 'LGPL-3',
     'author': 'Nova Code',
     'website': 'https://www.novacode.nl',

--- a/formio/i18n/de.po
+++ b/formio/i18n/de.po
@@ -1169,5 +1169,5 @@ msgstr "js"
 #: code:addons/formio/formio/models/formio_builder.py:160
 #: code:addons/formio/models/formio_builder.py:160
 #, python-format
-msgid "{title} (state: {state} - version: {version})"
-msgstr "{title} (Status: {state} - Version: {version})"
+msgid "{title} (state: {state}, version: {version})"
+msgstr "{title} (Status: {state}, Version: {version})"

--- a/formio/i18n/pt_BR.po
+++ b/formio/i18n/pt_BR.po
@@ -2142,5 +2142,5 @@ msgstr ""
 #. module: formio
 #: code:addons/formio/models/formio_builder.py:247
 #, python-format
-msgid "{title} (state: {state} - version: {version})"
-msgstr "{title} (state: {state} - versão: {version})"
+msgid "{title} (state: {state}, version: {version})"
+msgstr "{title} (state: {state}, versão: {version})"

--- a/formio/i18n/zh_CN.po
+++ b/formio/i18n/zh_CN.po
@@ -2265,5 +2265,5 @@ msgstr ""
 #. module: formio
 #: code:addons/formio/models/formio_builder.py:0
 #, python-format
-msgid "{title} (state: {state} - version: {version})"
-msgstr "{title} (状态: {state} - 版本号: {version})"
+msgid "{title} (state: {state}, version: {version})"
+msgstr "{title} (状态: {state}, 版本号: {version})"

--- a/formio/models/__init__.py
+++ b/formio/models/__init__.py
@@ -5,6 +5,7 @@ from . import formio_builder
 from . import formio_builder_js_options
 from . import formio_builder_translation
 from . import formio_default_asset_css
+from . import formio_builder_form_exclusive_partner
 from . import formio_form
 from . import formio_res_model
 from . import formio_version
@@ -16,3 +17,4 @@ from . import ir_attachment
 from . import ir_view
 from . import res_config_settings
 from . import res_lang
+from . import res_partner

--- a/formio/models/formio_builder.py
+++ b/formio/models/formio_builder.py
@@ -73,7 +73,7 @@ class Builder(models.Model):
         - Current: Live and in use (publisehd).
         - Obsolete: Was current but obsolete (unpublished)""")
     display_state = fields.Char("Display State", compute='_compute_display_fields', store=False)
-    display_name_full = fields.Char("Display Name Full", compute='_compute_display_fields', store=False)
+    display_name_full = fields.Char("Display Name Full", compute='_compute_display_fields', search='_search_display_name_full', store=False)
     parent_id = fields.Many2one('formio.builder', string='Parent Builder', readonly=True)
     parent_version = fields.Integer(related='parent_id.version', string='Parent Version', readonly=True)
     version = fields.Integer("Version", required=True, readonly=True, default=1)
@@ -213,6 +213,14 @@ class Builder(models.Model):
             schema = ast.literal_eval(schema)
         return schema
 
+    def _search_display_name_full(self, operator, value):
+        if value:
+            builders = self.search([('title', operator, value)])
+        if builders:
+            return [('id', 'in', builders.ids)]
+        else:
+            return [('id', '=', False)]
+
     @api.onchange('formio_js_options_id')
     def _onchange_formio_js_options_id(self):
         if self.formio_js_options_id:
@@ -250,7 +258,7 @@ class Builder(models.Model):
             if self._context.get('display_name_title'):
                 r.display_name_full = r.title
             else:
-                r.display_name_full = _("{title} (state: {state} - version: {version})").format(
+                r.display_name_full = _("{title} (state: {state}, version: {version})").format(
                     title=r.title, state=r.display_state, version=r.version)
 
     @api.depends('exclusive_partner_rel_ids')

--- a/formio/models/formio_builder_form_exclusive_partner.py
+++ b/formio/models/formio_builder_form_exclusive_partner.py
@@ -1,0 +1,20 @@
+# Copyright Nova Code (http://www.novacode.nl)
+# See LICENSE file for full licensing details.
+
+from odoo import fields, models
+
+
+class BuilderFormExclusivePartner(models.Model):
+    _name = 'formio.builder.form.exclusive.partner'
+    _description = 'Form Builder Form Exclusive Partner'
+
+    builder_id = fields.Many2one('formio.builder', string='Form Builder', required=True)
+    builder_uuid = fields.Char(related='builder_id.uuid', string='Form Builder UUID')
+    builder_title = fields.Char(related='builder_id.title', string='Form Builder Title')
+    builder_name = fields.Char(related='builder_id.name', string='Form Builder Name')
+    builder_version = fields.Integer(related='builder_id.version', string='Form Builder Version')
+    builder_state = fields.Selection(related='builder_id.state', string='Form Builder State')
+    partner_id = fields.Many2one('res.partner', required=True)
+    partner_parent_id = fields.Many2one('res.partner', related='partner_id.parent_id')
+    #partner_child_ids = fields.One2many('res.partner', related='partner_id.child_ids')
+    partner_company_type = fields.Selection(related='partner_id.company_type')

--- a/formio/models/formio_builder_form_exclusive_partner.py
+++ b/formio/models/formio_builder_form_exclusive_partner.py
@@ -1,7 +1,8 @@
 # Copyright Nova Code (http://www.novacode.nl)
 # See LICENSE file for full licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class BuilderFormExclusivePartner(models.Model):
@@ -18,3 +19,14 @@ class BuilderFormExclusivePartner(models.Model):
     partner_parent_id = fields.Many2one('res.partner', related='partner_id.parent_id')
     #partner_child_ids = fields.One2many('res.partner', related='partner_id.child_ids')
     partner_company_type = fields.Selection(related='partner_id.company_type')
+
+    @api.constrains('builder_id', 'partner_id')
+    def _constraint_unique_builder_and_partner(self):
+        for r in self:
+            res = self.search([
+                ("builder_id", "=", r.builder_id.id),
+                ("partner_id", "=", r.partner_id.id)
+            ])
+            if len(res) > 1:
+                msg = _("A Form Builder can only be exclusively assigned to a Partner once. Affected Form Builder:\n%s") % r.builder_id.display_name_full
+                raise ValidationError(msg)

--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -211,7 +211,7 @@ class Form(models.Model):
 
     def _compute_access(self):
         user_groups = self.env.user.groups_id
-        for form in self:
+        for form in self.sudo():
             # allow_unlink
             unlink_form = self.get_form(form.uuid, 'unlink')
             if unlink_form:

--- a/formio/models/res_partner.py
+++ b/formio/models/res_partner.py
@@ -1,0 +1,21 @@
+# Copyright Nova Code (http://www.novacode.nl)
+# See LICENSE file for full licensing details.
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    exclusive_formio_builder_form_rel_ids = fields.One2many(
+        'formio.builder.form.exclusive.partner', compute='_compute_exclusive_formio_builder_form_ids', string='Exclusive Forms')
+
+    def _compute_exclusive_formio_builder_form_ids(self):
+        for r in self:
+            domain = ['|', ('partner_id', '=', r.id), ('partner_id', 'parent_of', r.id)]
+            res = self.env['formio.builder.form.exclusive.partner'].search(domain)
+
+            if res:
+                r.exclusive_formio_builder_form_rel_ids = [(6, 0, res.ids)]
+            else:
+                r.exclusive_formio_builder_form_rel_ids = False

--- a/formio/models/res_partner.py
+++ b/formio/models/res_partner.py
@@ -8,7 +8,11 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     exclusive_formio_builder_form_rel_ids = fields.One2many(
-        'formio.builder.form.exclusive.partner', compute='_compute_exclusive_formio_builder_form_ids', string='Exclusive Forms')
+        'formio.builder.form.exclusive.partner', 'partner_id',
+        string='Exclusive Forms',
+        help='Give access only to Forms this partner (either linked directly to the partner or to its children). If left empty, this restriction doesn\'t apply.')
+    exclusive_formio_builder_form_ids = fields.One2many(
+        'formio.builder.form.exclusive.partner', compute='_compute_exclusive_formio_builder_form_ids', string='Exclusive Forms determined')
 
     def _compute_exclusive_formio_builder_form_ids(self):
         for r in self:
@@ -16,6 +20,6 @@ class ResPartner(models.Model):
             res = self.env['formio.builder.form.exclusive.partner'].search(domain)
 
             if res:
-                r.exclusive_formio_builder_form_rel_ids = [(6, 0, res.ids)]
+                r.exclusive_formio_builder_form_ids = [(6, 0, res.ids)]
             else:
-                r.exclusive_formio_builder_form_rel_ids = False
+                r.exclusive_formio_builder_form_ids = False

--- a/formio/security/ir_model_access.xml
+++ b/formio/security/ir_model_access.xml
@@ -384,5 +384,16 @@ See LICENSE file for full copyright and licensing details. -->
             <field name="perm_write" eval="1"/>
             <field name="perm_unlink" eval="1"/>
         </record>
+
+        <!-- Formio Exclusive Partner Model -->
+        <record id="access_formio_builder_form_exclusive_partner_admin" model="ir.model.access">
+            <field name="name">formio.builder.form.exclusive.partner: Admin</field>
+            <field name="model_id" ref="formio.model_formio_builder_form_exclusive_partner"/>
+            <field name="group_id" ref="formio.group_formio_admin"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_write" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
     </data>
 </odoo>

--- a/formio/security/ir_rule.xml
+++ b/formio/security/ir_rule.xml
@@ -4,6 +4,7 @@ See LICENSE file for full copyright and licensing details. -->
 
 <odoo>
     <data>
+        <!-- read, write, create -->
         <record id="formio_form_user_all" model="ir.rule">
             <field name="name">formio.form: User all forms</field>
             <field name="model_id" ref="model_formio_form"/>
@@ -26,6 +27,24 @@ See LICENSE file for full copyright and licensing details. -->
             <field name="domain_force">[('user_id', '=', user.id)]</field>
         </record>
 
+        <record id="formio_form_portal_user" model="ir.rule">
+            <field name="name">formio.form: Portal user forms</field>
+            <field name="model_id" ref="model_formio_form"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+            <field name="domain_force">
+                [
+                '&amp;',
+                ('portal_share', '=', True),
+                '|', ('create_uid', '=', user.id), ('submission_partner_id', '=', user.partner_id.id)
+                ]
+            </field>
+        </record>
+
+        <!-- unlink (delete) -->
         <record id="formio_form_unlink_user_assigned" model="ir.rule">
             <field name="name">formio.form unlink: User assigned forms</field>
             <field name="model_id" ref="model_formio_form"/>
@@ -37,17 +56,6 @@ See LICENSE file for full copyright and licensing details. -->
             <field name="domain_force">
                 [('create_uid', '=', user.id), ('user_id', '=', user.id), ('state', '!=', 'COMPLETE')]
             </field>
-        </record>
-
-        <record id="formio_form_portal_user" model="ir.rule">
-            <field name="name">formio.form read, write: Portal User</field>
-            <field name="model_id" ref="model_formio_form"/>
-            <field name="perm_read" eval="True"/>
-            <field name="perm_write" eval="True"/>
-            <field name="perm_create" eval="False"/>
-            <field name="perm_unlink" eval="False"/>
-            <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
-            <field name="domain_force">[('builder_id.portal', '=', True), ('user_id', '=', user.id)]</field>
         </record>
 
         <record id="formio_form_unlink_portal_user" model="ir.rule">
@@ -63,7 +71,26 @@ See LICENSE file for full copyright and licensing details. -->
                 '&amp;',
                 '&amp;',
                 '&amp;',
-                ('builder_id.portal', '=', True), ('create_uid', '=', user.id), ('user_id', '=', user.id), ('state', '!=', 'COMPLETE')]
+                ('portal_share', '=', True), ('create_uid', '=', user.id), ('user_id', '=', user.id), ('state', '!=', 'COMPLETE')]
+            </field>
+        </record>
+
+        <!-- exclusive forms (portal) -->
+        <record id="formio_builder_read_exclusive_user_portal_user" model="ir.rule">
+            <field name="name">formio.builder read: Exclusive Users Portal User</field>
+            <field name="model_id" ref="model_formio_builder"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+            <field name="domain_force">
+                [
+                '|', '|',
+                '&amp;', ('portal', '=', True), ('exclusive_partner_ids', '=', False),
+                '&amp;', ('portal', '=', True), ('exclusive_partner_ids', '=', user.partner_id.id),
+                '&amp;', ('portal', '=', True), ('exclusive_partner_ids', '=', user.partner_id.parent_id.id)
+                ]
             </field>
         </record>
     </data>

--- a/formio/static/description/index.html
+++ b/formio/static/description/index.html
@@ -173,6 +173,14 @@
 <section class="oe_container">
   <div class="oe_row oe_spaced">
     <h2 class="oe_slogan" style="color:#875A7B;">Releases</h2>
+    <h4 class="oe_mb16">9.0</h4>
+    <ul>
+      <li>
+        New feature: Exclusive Forms for Portal users (respecting Partner hierarchy).<br/>
+        Configuration can be done per Form Builder, with respecting the Partner hierarchy.<br/>
+        Forms (builders) assigned to Partners are available to all Child Partners.
+      </li>
+    </ul>
     <h4 class="oe_mb16">8.17</h4>
     <ul>
       <li>

--- a/formio/static/description/index.html
+++ b/formio/static/description/index.html
@@ -179,6 +179,13 @@
         New feature: Exclusive Forms for Portal users (respecting Partner hierarchy).<br/>
         Configuration can be done per Form Builder, with respecting the Partner hierarchy.<br/>
         Forms (builders) assigned to Partners are available to all Child Partners.
+    </ul>
+    <h4 class="oe_mb16">8.18</h4>
+    <ul>
+      <li>
+        Fix: Issue in Form (form-view) searching Builder(s) really didn't worked properly.<br/>
+        Technical details:<br/>
+        This change addresses the <code>formio.builder</code>, adding the <code>search</code> method for the computed field <code>display_name_full</code> which is used as <code>_rec_name</code>.
       </li>
     </ul>
     <h4 class="oe_mb16">8.17</h4>

--- a/formio/static/description/index.html
+++ b/formio/static/description/index.html
@@ -179,6 +179,7 @@
         New feature: Exclusive Forms for Portal users (respecting Partner hierarchy).<br/>
         Configuration can be done per Form Builder, with respecting the Partner hierarchy.<br/>
         Forms (builders) assigned to Partners are available to all Child Partners.
+      </li>
     </ul>
     <h4 class="oe_mb16">8.18</h4>
     <ul>

--- a/formio/views/formio_builder_views.xml
+++ b/formio/views/formio_builder_views.xml
@@ -135,6 +135,20 @@ See LICENSE file for full licensing details. -->
                         </page>
                         <page string="Resource" name="res_model_settings" attrs="{'invisible': [('formio_res_model_id', '=', False)]}"/>
                         <page string="Portal" name="portal_settings">
+                            <group name="exclusive_partners" string="Exclusive Forms" attrs="{'invisible': [('formio_res_model_id', '!=', False)]}">
+                                <div class="mb-3 text-muted" colspan="2">
+                                    <i class="fa fa-info-circle" title="info"/> Give access only to Users related to the Partners below, either linked directly to the Partner or to its children.<br/>
+                                    If left empty, this restriction doesn't apply and Forms are available by obtaining other configuration.
+                                </div>
+                                <field name="exclusive_partner_rel_ids" string="Partners">
+                                    <tree editable="bottom" default_order="partner_id asc">
+                                        <field name="builder_id" invisible="1"/>
+                                        <field name="partner_id"/>
+                                        <field name="partner_company_type"/>
+                                        <field name="partner_parent_id"/>
+                                    </tree>
+                                </field>
+                            </group>
                             <group>
                                 <group string="Redirect After Submit">
                                     <field name="portal_submit_done_url" groups="formio.group_formio_admin" string="Redirect URL" readonly="0"/>
@@ -261,6 +275,7 @@ See LICENSE file for full licensing details. -->
             <search string="Form Builders">
                 <field name="title"/>
                 <field name="name"/>
+                <field name="exclusive_partner_ids" filter_domain="[('exclusive_partner_ids.partner_id', 'ilike', self)]"/>
                 <field name="user_id"/>
                 <field name="formio_version_id"/>
                 <separator/>
@@ -278,6 +293,11 @@ See LICENSE file for full licensing details. -->
                         domain="[('portal', '=', True)]"/>
                 <filter string="Not Portal" name="not_portal"
                         domain="[('portal', '=', False)]"/>
+                <separator/>
+                <filter string="Exclusive assigned to Partners (in Portal)" name="exclusive_partners"
+                        domain="[('exclusive_partner_rel_ids', '!=', False)]"/>
+                <filter string="Not Exclusive assigned to Partners (in Portal)" name="not_exclusive_partners"
+                        domain="[('exclusive_partner_rel_ids', '=', False)]"/>
                 <separator/>
                 <filter string="Wizard" name="wizard"
                         domain="[('wizard', '=', True)]"/>

--- a/formio/views/res_partner_views.xml
+++ b/formio/views/res_partner_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright Nova Code (http://www.novacode.nl)
+See LICENSE file for full licensing details. -->
+
+<odoo>
+    <record id="view_partner_form_formio_partner" model="ir.ui.view">
+        <field name="name">res.partner.form.formio.partner</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <page name="internal_notes" position="before">
+                <page name="formio_form_exclusive" string="Exclusive Forms">
+                    <div class="text-muted" colspan="2">
+                        <i class="fa fa-info-circle" title="info"/> Forms exclusive accessible in the <strong>Portal</strong><br/>
+                        Configuration (assign to partners, contacts) can be done per Form Builder.
+                    </div>
+                    <field name="exclusive_formio_builder_form_rel_ids">
+                        <tree create="false" edit="false" delete="false" default_order="builder_title, builder_version desc">
+                            <field name="builder_uuid" optional="hide"/>
+                            <field name="builder_title" string="Title"/>
+                            <field name="builder_name" optional="show" string="Name"/>
+                            <field name="builder_version" optional="show" string="Version"/>
+                            <field name="builder_state" optional="show" string="State"/>
+                            <field name="partner_id" optional="hide" string="Partner"/>
+                            <field name="partner_company_type" optional="hide"/>
+                        </tree>
+                    </field>
+                </page>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/formio/views/res_partner_views.xml
+++ b/formio/views/res_partner_views.xml
@@ -9,22 +9,42 @@ See LICENSE file for full licensing details. -->
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <page name="internal_notes" position="before">
-                <page name="formio_form_exclusive" string="Exclusive Forms">
+                <page name="formio_form_exclusive" string="Exclusive Portal Forms">
                     <div class="text-muted" colspan="2">
                         <i class="fa fa-info-circle" title="info"/> Forms exclusive accessible in the <strong>Portal</strong><br/>
                         Configuration (assign to partners, contacts) can be done per Form Builder.
                     </div>
-                    <field name="exclusive_formio_builder_form_rel_ids">
-                        <tree create="false" edit="false" delete="false" default_order="builder_title, builder_version desc">
-                            <field name="builder_uuid" optional="hide"/>
-                            <field name="builder_title" string="Title"/>
-                            <field name="builder_name" optional="show" string="Name"/>
-                            <field name="builder_version" optional="show" string="Version"/>
-                            <field name="builder_state" optional="show" string="State"/>
-                            <field name="partner_id" optional="hide" string="Partner"/>
-                            <field name="partner_company_type" optional="hide"/>
-                        </tree>
-                    </field>
+                    <group>
+                        <group colspan="2" name="formio_forms">
+                            <label string="Forms Direct Assignment" for="exclusive_formio_builder_form_rel_ids" colspan="2" class="mb16"/>
+                            <field name="exclusive_formio_builder_form_rel_ids" nolabel="1">
+                                <tree editable="bottom" default_order="builder_title, builder_version desc">
+                                    <field name="partner_id" invisible="1"/>
+                                    <field name="builder_id"/>
+                                    <field name="builder_uuid" string="UUID" optional="hide"/>
+                                    <field name="builder_title" string="Title"/>
+                                    <field name="builder_name" string="Name" optional="show"/>
+                                    <field name="builder_version" string="Version" optional="show"/>
+                                    <field name="builder_state" string="State" optional="show" />
+                                </tree>
+                            </field>
+                        </group>
+                        <group colspan="2" name="formio_forms_determined">
+                            <label string="Forms Determined (direct or parent assignment)" for="exclusive_formio_builder_form_ids" colspan="2" class="mb16"/>
+                            <field name="exclusive_formio_builder_form_ids" nolabel="1">
+                                <tree create="false" edit="false" delete="false" default_order="builder_title, builder_version desc">
+                                    <field name="builder_id"/>
+                                    <field name="builder_uuid" optional="hide" string="UUID"/>
+                                    <field name="builder_title" string="Title"/>
+                                    <field name="builder_name" string="Name" optional="show"/>
+                                    <field name="builder_version" string="Version" optional="show"/>
+                                    <field name="builder_state" string="State" optional="show" />
+                                    <field name="partner_id" string="Partner" optional="hide"/>
+                                    <field name="partner_company_type" optional="hide"/>
+                                </tree>
+                            </field>
+                        </group>
+                    </group>
                 </page>
             </page>
         </field>

--- a/formio_component_recaptcha_button/static/src/js/formio_component_recaptcha.js
+++ b/formio_component_recaptcha_button/static/src/js/formio_component_recaptcha.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
 
         static schema(...extend) {
             return super.schema({
-                "label": "(odoo) reCAPTCHA",
+                "label": "reCAPTCHA (odoo)",
                 "key": "odoo_recaptcha",
                 "type": "odoo_recaptcha",
                 "input": true
@@ -17,10 +17,10 @@ $(document).ready(function() {
 
         static get builderInfo() {
             return {
-                title: '(odoo) reCAPTCHA',
+                title: 'reCAPTCHA (odoo)',
                 group: 'advanced',
                 icon: 'refresh',
-                weight: 1010,
+                weight: 1100,
                 documentation: '#',
                 schema: this.schema()
             };

--- a/formio_component_recaptcha_button/static/src/js/formio_component_recaptcha_button.js
+++ b/formio_component_recaptcha_button/static/src/js/formio_component_recaptcha_button.js
@@ -16,10 +16,10 @@ $(document).ready(function() {
 
         static get builderInfo() {
             return {
-                title: '(odoo) reCAPTCHA Button',
+                title: 'reCAPTCHA Button (odoo)',
                 group: 'advanced',
                 icon: 'stop',
-                weight: 1010,
+                weight: 1100,
                 documentation: '#',
                 schema: this.schema()
             };

--- a/formio_storage_filestore/__manifest__.py
+++ b/formio_storage_filestore/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Forms | Storage Filestore',
     'summary': 'Store uploads/files by URL in Odoo filestore (attachments)',
-    'version': '0.5',
+    'version': '0.6',
     'license': 'LGPL-3',
     'author': 'Nova Code',
     'website': 'https://www.novacode.nl',

--- a/formio_storage_filestore/models/formio_form.py
+++ b/formio_storage_filestore/models/formio_form.py
@@ -10,14 +10,15 @@ class Form(models.Model):
     @api.model
     def create(self, vals):
         res = super(Form, self).create(vals)
-
-        res._process_storage_filestore_ir_attachments('create')
+        if vals.get('submission_data'):
+            res._process_storage_filestore_ir_attachments('create')
         return res
 
     def write(self, vals):
         submission_data = self.submission_data
         res = super(Form, self).write(vals)
-        self._process_storage_filestore_ir_attachments('write')
+        if vals.get('submission_data'):
+            self._process_storage_filestore_ir_attachments('write')
         return res
 
     def _process_storage_filestore_ir_attachments(self, mode):
@@ -30,7 +31,10 @@ class Form(models.Model):
 
         # update ir.attachment (link with formio.form)
         if attach_names:
-            domain = [('name', 'in', attach_names)]
+            domain = [
+                ('name', 'in', attach_names),
+                ('formio_storage_filestore_user_id', '!=', False)
+            ]
             attachments = self.env['ir.attachment'].search(domain)
             for attach in attachments:
                 vals = {

--- a/formio_storage_filestore/static/description/index.html
+++ b/formio_storage_filestore/static/description/index.html
@@ -60,6 +60,12 @@
 <section class="oe_container">
   <div class="oe_row oe_spaced">
     <h2 class="oe_slogan" style="color:#875A7B;">Releases</h2>
+    <h4 class="oe_mb16">0.6</h4>
+    <ul>
+      <li>
+        Improvement: Only process a Form its filestore/attachments upon saving submission data.
+      </li>
+    </ul>
     <h4 class="oe_mb16">0.5</h4>
     <ul>
       <li>


### PR DESCRIPTION
Configuration can be done per Form Builder, with respecting the Partner hierarchy.
Forms (builders) assigned to Partners are available to all Child Partners.

Implementing #113