### PR TITLE
Users without formio groups can't view report button

### DIFF
--- a/formio_report_qweb/models/ir_actions_report.py
+++ b/formio_report_qweb/models/ir_actions_report.py
@@ -8,4 +8,4 @@ class IrActionsReportXml(models.Model):
     _inherit = 'ir.actions.report'
 
     formio_builder_report_ids = fields.One2many(
-        'formio.builder.report', 'ir_actions_report_id', string='Form Builder Reports')
+        'formio.builder.report', 'ir_actions_report_id', string='Form Builder Reports', groups='formio.group_formio_user')


### PR DESCRIPTION
The users without any of the formio groups cannot view the report button.
Adding the groups parameter fix the problem.