### PR TITLE
Fixes the 'faded' signature images on PDF version of form

### DIFF
--- a/formio_report_qweb/report/report_formio_form_components.xml
+++ b/formio_report_qweb/report/report_formio_form_components.xml
@@ -285,7 +285,7 @@ See LICENSE file for full copyright and licensing details.
         <div class="mw-100 mb-3 formio_signature_component">
             <t t-if="component.value">
                 <div class="label mb-2"><t t-call="formio_report_qweb.component_label"/></div>
-                <img t-att-src="component.value" t-att-alt="component.label"/>
+                <img t-att-src="component.value" t-att-alt="component.label" width="100%"/>
             </t>
             <t t-else="">
                 <div class="label mb-2"><t t-call="formio_report_qweb.component_label"/></div>


### PR DESCRIPTION
In some scenarios (which I can't figure out) the signature component is rendered 'faded' and the size is different when printing to PDF. When this happens the whole PDF's 'scale' is bigger. I played around with many possible fixes and found this one by trial and error. wkhtmltopdf has its flaws....

Before fix:
![image](https://user-images.githubusercontent.com/20549666/172977306-546c3433-1cff-4f05-93ca-4c7dfb66612d.png)

After Fix:
![image](https://user-images.githubusercontent.com/20549666/172977424-ece19ca6-b6a6-4719-93f2-f01c26b0728c.png)
