### PR TITLE
[FIX] Avoid exception on hidden file components

### DIFF
--- a/formio_storage_filestore/__manifest__.py
+++ b/formio_storage_filestore/__manifest__.py
@@ -16,7 +16,7 @@
         'data/ir_cron_data.xml'
     ],
     'application': True,
-    'installable': False,
+    'installable': True,
     'images': [
         'static/description/banner.gif',
     ],

--- a/formio_storage_filestore/models/formio_form.py
+++ b/formio_storage_filestore/models/formio_form.py
@@ -67,14 +67,16 @@ class Form(models.Model):
             ]
             if attach_names:
                 domain.append(('name', 'not in', attach_names))
-            self.env['ir.attachment'].search(domain).\
-                with_context(formio_storage_filestore_force_unlink_attachment=True).\
+            self.env['ir.attachment'].search(domain). \
+                with_context(formio_storage_filestore_force_unlink_attachment=True). \
                 unlink()
 
     def _get_component_file_names(self, component_obj):
         names = []
-        if hasattr(component_obj, 'storage') and component_obj.storage == 'url' \
-           and '/formio/storage/filestore' in component_obj.url:
+        if (hasattr(component_obj, 'storage')
+                and component_obj.storage == 'url'
+                and '/formio/storage/filestore' in component_obj.url
+                and component_obj.value):
             for val in component_obj.value:
                 names.append(val['name'])
         return names

--- a/formio_storage_filestore/models/formio_form.py
+++ b/formio_storage_filestore/models/formio_form.py
@@ -67,8 +67,8 @@ class Form(models.Model):
             ]
             if attach_names:
                 domain.append(('name', 'not in', attach_names))
-            self.env['ir.attachment'].search(domain). \
-                with_context(formio_storage_filestore_force_unlink_attachment=True). \
+            self.env['ir.attachment'].search(domain).\
+                with_context(formio_storage_filestore_force_unlink_attachment=True).\
                 unlink()
 
     def _get_component_file_names(self, component_obj):


### PR DESCRIPTION
Then problem is that hidden file component doesn't have a list
as value, and therefore when trying to iterate it an exception is
raised and make to fail the rest of the form.