### PR TITLE
[IMP] Allow to correctly set default values for selectable fields

### DIFF
--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -10,6 +10,7 @@ import uuid
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
+from odoo.fields import first
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import AccessError, UserError
 
@@ -563,3 +564,15 @@ class Form(models.Model):
             )
         else:
             _logger.error('No user configured (in settings) for mail_activity_partner_linking')
+
+    @api.model
+    def traverse_path(self, path, record):
+        value = None
+        split_path = path.split('.')
+        try:
+            for name in split_path[:-1]:
+                record = first(record[name])
+            value = record[split_path[-1]]
+        except KeyError:
+            _logger.error('Incorrect API default value path: %s' % path)
+        return value


### PR DESCRIPTION
Most of the time it works nicely, but for the case when the formio selectable field is fetching the options from Odoo, it's not possible to correctly set the value as expected by formio (in general an object with the shame {id: int: label: string}).

This PR allows to do that, and at the same time, makes possible to include more data in the options values that can be used in the option template or used by other field's logic.

So correct configuration for /data url selectable fields could be: user_field; {id: partner_id.id, label: partner_id.name}

but even could be:
{id: partner_id.id, label: partner_id.name, country: partner_id.country_id.name}