### PR TITLE
[IMP] Prevent exception on bad configured field

### DIFF
--- a/formio_data_api/models/formio_form.py
+++ b/formio_data_api/models/formio_form.py
@@ -307,6 +307,7 @@ class FormioForm(models.Model):
 
         fields = field_getter.split('.')
         fields_done = []
+        odoo_field_val = False
 
         for field in fields:
             try:


### PR DESCRIPTION
When a related field is not well configured using they etl res_field key and it fails, all the other fields also don't get updated.

Instead, would be better to just let that bad configured field to don't display any default value, but for the rest well configure, show their values.