### PR TITLE
[IMP] Prevent fully override hooks to allow extension

### DIFF
--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -162,7 +162,8 @@ export class OdooFormioForm extends Component {
                 if (instance.component.type == 'datetime') {
                     self._localizeComponent(instance.component, self.language);
                 }
-            }
+            },
+            ...self['options']['hooks'],
         };
         Formio.createForm(document.getElementById('formio_form'), self.schema, self.options).then(function(form) {
             window.setLanguage = function(lang) {


### PR DESCRIPTION
When the options hooks has being extended by any other external module code, at this point, those values are fully override and the only allowed hook to persist is the one coded here `attachComponent`.

By adding the suggested line bellow, we allow to persists any other hooks added previously to this form from other modules.