### PR TITLE
Issue #98 - Language button highlight implementation

### DIFF
--- a/formio/static/src/css/formio_builder_embed.css
+++ b/formio/static/src/css/formio_builder_embed.css
@@ -16,5 +16,13 @@ body {
 }
 
 .formio_languages button {
-    border: 1px solid #d8d8d8;
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid #000000;
+}
+
+.btn.language_button_active {
+    background-color: #6e757c;
+    color: #ffffff;
+    border: 1px solid #6e757c;
 }

--- a/formio/static/src/css/formio_form_embed.css
+++ b/formio/static/src/css/formio_form_embed.css
@@ -40,5 +40,13 @@ h3.formio_form_title {
 }
 
 .formio_languages button {
-    border: 1px solid #d8d8d8;
+    border: 1px solid #000000;
+    background-color:white;
+    color:black;
+}
+
+.btn.language_button_active {
+    background-color:#6e757c;
+    color:white;
+    border: 1px solid #6e757c;
 }

--- a/formio/static/src/js/builder/app.js
+++ b/formio/static/src/js/builder/app.js
@@ -42,15 +42,28 @@ function app() {
         createBuilder() {
             const self = this;
             let builder = new Formio.FormBuilder(document.getElementById('formio_builder'), self.schema, self.options);
+            let buttons = document.querySelectorAll('.formio_languages button');
+            
+            buttons.forEach(function(btn) {
+                if (self.options.language === btn.lang) {
+                    btn.classList.add('language_button_active');
+                };
+            });
 
             builder.instance.ready.then(function() {
                 if ('language' in self.options) {
                     builder.language = self.options['language'];
                     // builder.instance.webform.language = self.options['language'];
                 }
-                window.setLanguage = function(lang) {
+                window.setLanguage = function(lang, button) {
                     builder.instance.webform.language = lang;
                     builder.instance.redraw();
+                    let buttons = document.querySelectorAll('.formio_languages button');
+
+                    buttons.forEach(function(btn) {
+                        btn.classList.remove('language_button_active');
+                    });
+                    button.classList.add('language_button_active');
                 };
             });
 

--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -159,10 +159,30 @@ export class OdooFormioForm extends Component {
                 }
             }
         };
+
         Formio.createForm(document.getElementById('formio_form'), self.schema, self.options).then(function(form) {
-            window.setLanguage = function(lang) {
+            var buttons = document.querySelectorAll('.formio_languages button');
+            
+            buttons.forEach(function(btn) {
+                
+                if (self.language === btn.lang) {
+                    btn.classList.add('language_button_active');
+                };
+            });
+
+            window.setLanguage = function(lang, button) {
+                console.log(lang)
                 self.language = lang;
                 form.language = lang;
+                var buttons = document.querySelectorAll('.formio_languages button');
+
+                buttons.forEach(function(btn) {
+                    btn.classList.remove('language_button_active');
+                });
+                button.classList.add('language_button_active');
+
+                
+
                 // component with URL filter: add language
                 FormioUtils.eachComponent(form.components, (component) => {
                     let compObj = component.component;

--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -171,7 +171,7 @@ export class OdooFormioForm extends Component {
             });
 
             window.setLanguage = function(lang, button) {
-                console.log(lang)
+                
                 self.language = lang;
                 form.language = lang;
                 var buttons = document.querySelectorAll('.formio_languages button');

--- a/formio/views/formio_builder_templates.xml
+++ b/formio/views/formio_builder_templates.xml
@@ -47,7 +47,7 @@ See LICENSE file for full licensing details. -->
                 <t t-if="len(builder_languages) > 1">
                     <div class="formio_languages">
                         <t t-foreach="builder_languages" t-as="lang">
-                            <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}')"><span t-field="lang.name"/></button>
+                            <button class="btn btn-sm btn-default" t-att-lang="lang.formio_ietf_code" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}', this)"><span t-field="lang.name"/></button>
                         </t>
                     </div>
                 </t>

--- a/formio/views/formio_form_templates.xml
+++ b/formio/views/formio_form_templates.xml
@@ -113,7 +113,7 @@ See LICENSE file for full licensing details. -->
                 <t t-if="len(form_languages) > 1">
                     <div class="formio_languages">
                         <t t-foreach="form_languages" t-as="lang">
-                            <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}')">
+                            <button class="btn btn-sm btn-default" t-att-lang="lang.formio_ietf_code" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}', this)">
                                 <span t-out="lang.name"/>
                             </button>
                         </t>

--- a/formio/views/formio_portal_templates.xml
+++ b/formio/views/formio_portal_templates.xml
@@ -184,7 +184,7 @@ See LICENSE file for full licensing details. -->
                 <t t-if="len(form_languages) > 1">
                     <div class="formio_languages">
                         <t t-foreach="form_languages" t-as="lang">
-                            <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}')">
+                            <button class="btn btn-sm btn-default" t-att-lang="lang.formio_ietf_code" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}', this)">
                                 <span t-out="lang.name"/>
                             </button>
                         </t>

--- a/formio/views/formio_public_templates.xml
+++ b/formio/views/formio_public_templates.xml
@@ -77,7 +77,7 @@ See LICENSE file for full licensing details. -->
                 <t t-if="len(form_languages) > 1">
                     <div class="formio_languages">
                         <t t-foreach="form_languages" t-as="lang">
-                            <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}')">
+                            <button class="btn btn-sm btn-default" t-att-lang="lang.formio_ietf_code" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}', this)">
                                 <span t-out="lang.name"/>
                             </button>
                         </t>
@@ -141,7 +141,7 @@ See LICENSE file for full licensing details. -->
                 <t t-if="len(form_languages) > 1">
                     <div class="formio_languages">
                         <t t-foreach="form_languages" t-as="lang">
-                            <button class="btn btn-sm btn-default" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}')">
+                            <button class="btn btn-sm btn-default" t-att-lang="lang.formio_ietf_code" t-attf-onclick="setLanguage('{{ lang.formio_ietf_code }}', this)">
                                 <span t-out="lang.name"/>
                             </button>
                         </t>


### PR DESCRIPTION
Added the highlight functionality on the language buttons, so that it is clear which language is currently active.

Functionality works on all custom add on modules (Formio/Website). 

UX design could be updated in future