### PR TITLE
Make Formio CDN for hot-loaded dependencies configurable

### DIFF
--- a/formio/__manifest__.py
+++ b/formio/__manifest__.py
@@ -28,6 +28,7 @@
         'data/formio_asset_data.xml',
         'data/formio_extra_asset_data.xml',
         'data/formio_default_version_data.xml',
+        'data/ir_config_param.xml',
         'data/ir_cron_data.xml',
         'data/mail_activity_data.xml',
         'data/mail_template_data.xml',

--- a/formio/data/ir_config_param.xml
+++ b/formio/data/ir_config_param.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Copyright Nova Code (http://www.novacode.nl)
+License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html) -->
+
+<odoo>
+    <data noupdate="1">
+        <record id="ir_config_param_formio_cdn_base_url" model="ir.config_parameter">
+	  <field name="key">formio.cdn_base_url</field>
+          <field name="value">https://cdnjs.cloudflare.com/ajax/libs</field>
+        </record>
+    </data>
+</odoo>

--- a/formio/models/formio_builder.py
+++ b/formio/models/formio_builder.py
@@ -524,12 +524,15 @@ class Builder(models.Model):
 
     def _get_js_params(self):
         """ Odoo JS (Owl component) misc. params """
+        Param = self.env['ir.config_parameter'].sudo()
+        cdn_base_url = Param.get_param('formio.cdn_base_url')
         params = {
             'portal_save_draft_done_url': self.portal_save_draft_done_url,
             'portal_submit_done_url': self.portal_submit_done_url,
             'readOnly': self.is_locked,
             'wizard_on_change_page_save_draft': self.wizard and self.wizard_on_change_page_save_draft,
-            'submission_url_add_query_params_from': self.submission_url_add_query_params_from
+            'submission_url_add_query_params_from': self.submission_url_add_query_params_from,
+            'cdn_base_url': cdn_base_url
         }
         return params
 

--- a/formio/models/formio_form.py
+++ b/formio/models/formio_form.py
@@ -596,12 +596,15 @@ class Form(models.Model):
 
     def _get_js_params(self):
         """ Odoo JS (Owl component) misc. params """
+        Param = self.env['ir.config_parameter'].sudo()
+        cdn_base_url = Param.get_param('formio.cdn_base_url')
         params = {
             'portal_save_draft_done_url': self.portal_save_draft_done_url,
             'portal_submit_done_url': self.portal_submit_done_url,
             'public_save_draft_done_url': self.public_save_draft_done_url,
             'public_submit_done_url': self.public_submit_done_url,
-            'wizard_on_change_page_save_draft': self.builder_id.wizard and self.builder_id.wizard_on_change_page_save_draft
+            'wizard_on_change_page_save_draft': self.builder_id.wizard and self.builder_id.wizard_on_change_page_save_draft,
+            'cdn_base_url': cdn_base_url
         }
         return params
 

--- a/formio/static/src/js/builder/app.js
+++ b/formio/static/src/js/builder/app.js
@@ -40,12 +40,17 @@ function app() {
         }
 
 	patchCDN() {
-	    // CDN class is not exported, so patch it here because ckeditor's URLs are somewhat nonstandard
+	    // CDN class is not exported, so patch it here because
+	    // ckeditor's URLs are somewhat nonstandard.
+	    // When using an external CDN, we must also avoid loading the customized
+	    // version of flatpickr, instead relying on the default version.
 	    const oldBuildUrl = Formio.cdn.buildUrl.bind(Formio.cdn);
 	    Formio.cdn.buildUrl = function(cdnUrl, lib, version) {
 		if (lib == 'ckeditor') {
 		    if (version == '19.0.0') version = '19.0.1'; // Somehow 19.0.0 is missing?!
 		    return `${cdnUrl}/${lib}5/${version}`;
+		} else if (lib == 'flatpickr-formio') {
+		    return oldBuildUrl(cdnUrl, 'flatpickr', this.libs['flatpickr']);
 		} else {
 		    return oldBuildUrl(cdnUrl, lib, version);
 		}

--- a/formio/static/src/js/builder/app.js
+++ b/formio/static/src/js/builder/app.js
@@ -41,6 +41,10 @@ function app() {
 
         createBuilder() {
             const self = this;
+
+	    // For privacy, ensure when unconfigured, no 3rd party requests are done
+	    Formio.cdn.setBaseUrl(self.params['cdn_base_url'] || window.location.href);
+
             let builder = new Formio.FormBuilder(document.getElementById('formio_builder'), self.schema, self.options);
             let buttons = document.querySelectorAll('.formio_languages button');
             

--- a/formio/static/src/js/builder/app.js
+++ b/formio/static/src/js/builder/app.js
@@ -39,9 +39,23 @@ function app() {
             });
         }
 
+	patchCDN() {
+	    // CDN class is not exported, so patch it here because ckeditor's URLs are somewhat nonstandard
+	    const oldBuildUrl = Formio.cdn.buildUrl.bind(Formio.cdn);
+	    Formio.cdn.buildUrl = function(cdnUrl, lib, version) {
+		if (lib == 'ckeditor') {
+		    if (version == '19.0.0') version = '19.0.1'; // Somehow 19.0.0 is missing?!
+		    return `${cdnUrl}/${lib}5/${version}`;
+		} else {
+		    return oldBuildUrl(cdnUrl, lib, version);
+		}
+	    }
+	}
+
         createBuilder() {
             const self = this;
 
+	    this.patchCDN();
 	    // For privacy, ensure when unconfigured, no 3rd party requests are done
 	    Formio.cdn.setBaseUrl(self.params['cdn_base_url'] || window.location.href);
 

--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -169,6 +169,19 @@ export class OdooFormioForm extends Component {
             && !$.isEmptyObject(component.data.url);
     }
 
+    patchCDN() {
+	// CDN class is not exported, so patch it here because ckeditor's URLs are somewhat nonstandard
+	const oldBuildUrl = Formio.cdn.buildUrl.bind(Formio.cdn);
+	Formio.cdn.buildUrl = function(cdnUrl, lib, version) {
+	    if (lib == 'ckeditor') {
+		if (version == '19.0.0') version = '19.0.1'; // Somehow 19.0.0 is missing?!
+		return `${cdnUrl}/${lib}5/${version}`;
+	    } else {
+		return oldBuildUrl(cdnUrl, lib, version);
+	    }
+	}
+    }
+
     createForm() {
         const self = this;
         // this does some flatpickr (datetime) locale all over the place.
@@ -176,6 +189,7 @@ export class OdooFormioForm extends Component {
             (window).flatpickr.localize((window).flatpickr.l10ns[self.defaultLocaleShort]);
         }
 
+	this.patchCDN();
 	// For privacy, ensure when unconfigured, no 3rd party requests are done
 	Formio.cdn.setBaseUrl(self.params['cdn_base_url'] || window.location.href);
 

--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -175,6 +175,10 @@ export class OdooFormioForm extends Component {
         if ('language' in self.options && window.flatpickr != undefined) {
             (window).flatpickr.localize((window).flatpickr.l10ns[self.defaultLocaleShort]);
         }
+
+	// For privacy, ensure when unconfigured, no 3rd party requests are done
+	Formio.cdn.setBaseUrl(self.params['cdn_base_url'] || window.location.href);
+
         Formio.setBaseUrl(window.location.href);
         self['options']['hooks'] = {
             attachComponent: (element, instance) => {

--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -170,12 +170,17 @@ export class OdooFormioForm extends Component {
     }
 
     patchCDN() {
-	// CDN class is not exported, so patch it here because ckeditor's URLs are somewhat nonstandard
+	// CDN class is not exported, so patch it here because
+	// ckeditor's URLs are somewhat nonstandard.
+	// When using an external CDN, we must also avoid loading the customized
+	// version of flatpickr, instead relying on the default version.
 	const oldBuildUrl = Formio.cdn.buildUrl.bind(Formio.cdn);
 	Formio.cdn.buildUrl = function(cdnUrl, lib, version) {
 	    if (lib == 'ckeditor') {
 		if (version == '19.0.0') version = '19.0.1'; // Somehow 19.0.0 is missing?!
 		return `${cdnUrl}/${lib}5/${version}`;
+	    } else if (lib == 'flatpickr-formio') {
+		return oldBuildUrl(cdnUrl, 'flatpickr', this.libs['flatpickr']);
 	    } else {
 		return oldBuildUrl(cdnUrl, lib, version);
 	    }


### PR DESCRIPTION
Make use of the formio.js CDN class to override the base URL for all 3rd party assets that are loaded on-the-fly by formio.js lib.
This includes for example ACE, CKEditor, Flatpickr, Quill etc.
    
This allows for improved privacy by using a CDN that honors the GDPR. Since I was unable to find any information about GDPR compliance of the default formio.js CDN, I've set the Cloudflare CDN as the default value.  Even though it's not perfect, they have at least a page about the GDPR: https://www.cloudflare.com/trust-hub/gdpr/
    
Commercial sites in the EU could choose to override the default value to a paid GDPR-aware CDN like KeyCDN.com or GlobalConnect.no and host the required files there, or simply point it to the base URL of their Odoo install and ship the files themselves.  This would require pinning the formio.js version, since different versions of the library need different dependencies.