### PR TITLE
[FIX] serve css content from ir.attachment instead of filesystem

### DIFF
--- a/formio/controllers/main.py
+++ b/formio/controllers/main.py
@@ -1,8 +1,8 @@
 # Copyright Nova Code (http://www.novacode.nl)
 # See LICENSE file for full licensing details.
-
 import json
 import logging
+from io import BytesIO
 
 from os.path import dirname
 
@@ -192,11 +192,6 @@ class FormioController(http.Controller):
             _logger.warning(msg)
             return request.not_found(msg)
 
-        attach_dir = dirname(attach.store_fname)
-        fonts_dir = '{attach_dir}/fonts/'.format(attach_dir=attach_dir)
-        fontfile_path = request.env['ir.attachment']._full_path(fonts_dir)
-        fontfile_path += '/%s' % name
-
         # TODO DeprecationWarning, odoo.http.send_file is deprecated.
         #
         # But:
@@ -207,7 +202,7 @@ class FormioController(http.Controller):
         # Workaround: (to improve/replace in futute?)
         # still using Odoo <= v15 approach by using Werkzeug
         # implementation
-        return send_file(fontfile_path, request.httprequest.environ,)
+        return send_file(BytesIO(attach.raw), request.httprequest.environ, download_name=attach.name)
 
     #########
     # Helpers

--- a/formio/models/formio_version_asset.py
+++ b/formio/models/formio_version_asset.py
@@ -10,7 +10,18 @@ class VersionAsset(models.Model):
     _order = 'sequence ASC'
 
     version_id = fields.Many2one('formio.version', string='formio.js version', ondelete='cascade')
-    type = fields.Selection([('js', 'js'), ('css', 'css'), ('license', 'license')], string='Type', required=True)
+    type = fields.Selection(
+        [
+            ("js", "js"),
+            ("css", "css"),
+            ("license", "license"),
+            ("eot", "EOT Font File"),
+            ("otf", "OTF Font File"),
+            ("svg", "SVG Font File"),
+            ("ttf", "TTF Font File"),
+            ("woff", "WOFF Font File"),
+            ("woff2", "WOFF2 Font File"),
+        ], string="Type", required=True)
     attachment_id = fields.Many2one(
         'ir.attachment', string="Attachment",
         required=True, ondelete='cascade', domain=[('res_model', '=', 'formio.version.asset')],

--- a/formio/models/formio_version_github_tag.py
+++ b/formio/models/formio_version_github_tag.py
@@ -219,18 +219,6 @@ class VersionGitHubTag(models.Model):
 
                         if file_ext == '.css':
                             asset_vals['type'] = 'css'
-
-                            src_fonts_path = '%s/dist/fonts' % src_version_path
-                            css_attach_dir = os.path.dirname(attachment.store_fname)
-                            css_attach_path = IrAttachment._full_path(css_attach_dir)
-                            target_fonts_path = '%s/fonts' % css_attach_path
-
-                            # XXX this leads to troubles if formio.js
-                            # versions ship different font files (version dependent).
-                            # However, the CSS url to resolve the fonts is expected to be
-                            # this precise one.
-                            if os.path.exists(src_fonts_path) and not os.path.exists(target_fonts_path):
-                                shutil.copytree(src_fonts_path, target_fonts_path)
                         elif file_ext == '.js':
                             asset_vals['type'] = 'js'
                         assets_vals_list.append(asset_vals)


### PR DESCRIPTION
This fixes https://github.com/novacode-nl/odoo-formio/issues/242
