### PR TITLE
[IMP] formio: Possibility to redirect the (parent) window upon submit of embedded public form.

### DIFF
--- a/formio/CHANGELOG.md
+++ b/formio/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 16.0.10.4
+
+Possibility to redirect the (parent) window upon submit of an embedded public form.
+
+The redirect occurs if the `<iframe/>` has set:
+- URL query-param `?embed` (any value allowed).
+- Following `sandbox` attribute with values (AFAIK): `sandbox="allow-same-origin allow-scripts allow-top-navigation"`
+
+### Example iframe
+
+(Sizing weight/height is not covered here):
+
+```html
+<iframe src="https://www.example.com/formio/public/form/new/some-UUID?embed=1"
+    sandbox="allow-same-origin allow-scripts allow-top-navigation"/>
+```
+
 ## 16.0.10.3
 
 Add Form component onBlur and onChange "Overlay timeout" (frontend) API.

--- a/formio/__manifest__.py
+++ b/formio/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Forms',
     'summary': 'Form Builder for backend, portal and website forms - to collect any information you need for your business.',
-    'version': '16.0.10.3',
+    'version': '16.0.10.4',
     'license': 'LGPL-3',
     'author': 'Nova Code',
     'website': 'https://www.novacode.nl',

--- a/formio/static/src/js/form/public_new_app.js
+++ b/formio/static/src/js/form/public_new_app.js
@@ -47,6 +47,12 @@ function app() {
             return this.params.hasOwnProperty('public_submit_done_url') && this.params.public_submit_done_url;
         }
 
+        isEmbed() {
+            const url = new URL(window.location);
+            const params = new URLSearchParams(url.search);
+            return params.has('embed');
+        }
+
         saveDraftDone(submission) {
             if (submission.state == 'draft') {
                 if (this.publicSaveDraftDoneUrl()) {
@@ -75,7 +81,10 @@ function app() {
             if (submission.state == 'submitted') {
                 if (this.publicSubmitDoneUrl()) {
                     const params = {submit_done_url: this.publicSubmitDoneUrl()};
-                    if (window.self !== window.top) {
+                    if (this.isEmbed()) {
+                        window.parent.location = params.submit_done_url;
+                    }
+                    else if (window.self !== window.top) {
                         window.parent.postMessage({odooFormioMessage: 'formioSubmitDone', params: params});
                     }
                     else {


### PR DESCRIPTION
Possibility to redirect the (parent) window upon submit of an embedded public form.

The redirect occurs if the `<iframe/>` has set:

- URL query-param `?embed` (any value allowed).
- Following `sandbox` attribute with values (AFAIK): `sandbox="allow-same-origin allow-scripts allow-top-navigation"`