### PR TITLE
[FIX] for scroll_into_view 

### DIFF
--- a/formio/static/src/js/formio_form_container.js
+++ b/formio/static/src/js/formio_form_container.js
@@ -21,7 +21,13 @@ $(document).ready(function() {
                 window.location = saveDraftDoneUrl;
             }
             else if (event.origin == baseUrl && msg == 'formioScrollIntoView' && scrollIntoViewSelector) {
-                document.querySelector(scrollIntoViewSelector, window.parent.parent.document).scrollIntoView();
+                let targetElement = document.querySelector(scrollIntoViewSelector);
+                if (!targetElement && window.parent && window.parent.parent) {
+                    targetElement = window.parent.parent.document.querySelector(scrollIntoViewSelector);
+                }
+                if (targetElement) {
+                    targetElement.scrollIntoView();
+                }
             }
             else if (event.origin == baseUrl && msg == 'formioScrollTop') {
                 window.parent.scrollTo(0, 0);


### PR DESCRIPTION
The problem was that as soon as you were not logged in, you got an odoo client error when you tried to click through a wizard. Instead of setting a default value I just ignore it. In our case this works very well on Odoo 17.0+e 