### PR TITLE
[IMP] formio: Add form submit slurpValue feature.

### DIFF
--- a/formio/CHANGELOG.md
+++ b/formio/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 17.0.6.0.10
+
+Possibility to override the form submit (input) value, by slurping from the input (DOM) element value.\
+This is especially useful for external JavaScript (scripts) that modify DOM input elements.
+
 ## 17.0.6.0.9
 
 Fix Form (action button) Send Invitation Mail, which is `formio.form` model method `action_send_invitation_mail`.

--- a/formio/__manifest__.py
+++ b/formio/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Forms',
     'summary': 'Form Builder for backend, portal, website and embedded forms, to collect any information you need for your business.',
-    'version': '17.0.6.0.9',
+    'version': '17.0.6.0.10',
     'license': 'LGPL-3',
     'author': 'Nova Code',
     'website': 'https://www.novaforms.app',

--- a/formio/static/src/js/form/formio_form.js
+++ b/formio/static/src/js/form/formio_form.js
@@ -527,6 +527,16 @@ export class OdooFormioForm extends Component {
             });
 
             form.on('submit', function(submission) {
+                form.everyComponent((component) => {
+                    let compObj = component.component;
+                    if (self.hasComponentPropertySlurpValue(compObj)) {
+                        if (component.refs.hasOwnProperty('input')) {
+                            const elementId = component.refs.input[0].id;
+                            const slurpVal = $("#" + elementId).val();
+                            submission.data[component.key] = slurpVal;
+                        }
+                    }
+                });
                 const data = {'data': submission.data};
                 self.postData(self.submitUrl, data).then(function(res) {
                     if (res.hasOwnProperty('error_message')) {
@@ -734,6 +744,13 @@ export class OdooFormioForm extends Component {
             && component.hasOwnProperty('data')
             && component.data.hasOwnProperty('url')
             && !$.isEmptyObject(component.data.url);
+    }
+
+    hasComponentPropertySlurpValue(component) {
+        return component
+            && component.hasOwnProperty('properties')
+            && component.properties.hasOwnProperty('slurpValue')
+            && !$.isEmptyObject(component.properties.slurpValue);
     }
 
     localizeComponent(component, language) {


### PR DESCRIPTION
Possibility to override the form submit (input) value, by slurping from the input (DOM) element value.
This is especially useful for external JavaScript (scripts) that modify DOM input elements.